### PR TITLE
No backfill!  Obscures missed updates!

### DIFF
--- a/bsasApp/src/receiver_pva.cpp
+++ b/bsasApp/src/receiver_pva.cpp
@@ -91,7 +91,9 @@ struct NumericScalarCopier : public PVAReceiver::ColCopy
 
             scratch[r] = elem[0];
 
-            column.last.swap(cell);
+            // NO backfill!  Backfill obscures whether or not we missed an update!!!
+            // column.last.swap(cell);
+            column.last.reset();
         }
 
         field->replace(pvd::freeze(scratch));


### PR DESCRIPTION
Backfill w/ stale values defeats the point of Beam Synchronous acquisition.
Each value in a row should have the same timestamp!